### PR TITLE
[FEATURE] Allow configuring different values per dataset per subsite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,56 +4,86 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.3.0 - 2025-08-22
+
+### Added
+
+- Added support for mulitple datasets per site
+
 ## 5.2.1 - 2025-07-03
+
 ### Fixed
+
 - Fixed validation error for random value when working with shapes
 
 ## 5.2.0 - 2025-06-23
+
 ### Added
+
 - Allow filtering for config value fields in the control panel
 
 ## 5.1.0 - 2025-06-19
+
 ### Added
+
 - Added support for single, double and triple color values, and shapes.
 
 ## 5.0.2 - 2025-02-14
+
 ### Fixed
+
 - Fixed a bug where the field couldn't be saved.
 
 ## 5.0.1 - 2025-02-14
+
 ### Added
+
 - Implement correct interfaces on field so it displays in overview grid and use type text so the value can be longer
 
 ## 5.0.0 - 2024-03-12
+
 ### Added
+
 - Craft 5 release 🚀
 
 ## 5.0.0-alpha.1 - 2023-12-22
+
 ### Added
+
 - Initial Craft 5 release 🚀
 
 ## 2.0.2 - 2023-02-15
+
 ### Fixed
+
 - Fixed a bug where the value from the radio field was not showing
 
 ## 2.0.1 - 2023-02-15
+
 ### Added
+
 - Radio type option
 
 ## 2.0.0 - 2022-05-05
+
 ### Added
+
 - Craft 4 🚀
 
 ## 2.0.0-beta.1 - 2022-04-13
+
 ### Added
+
 - Craft 4 compatibility
 
 ## 1.0.1 - 2021-12-03
+
 ### Added
+
 - Type options: dropdown or checkboxes
 
 ## 1.0.0 - 2019-10-31
+
 ### Added
+
 - Initial release
-
-

--- a/README.md
+++ b/README.md
@@ -3,26 +3,29 @@
 Populate field options from a centralized configuration file, providing consistent predefined values across multiple fields without hardcoding them into individual field settings.
 
 ## Requirements
+
 This plugin requires Craft CMS 5.0.0 or later.
 
 ## Features
 
 ![CleanShot 2025-06-19 at 16 53 21](https://github.com/user-attachments/assets/dc8c3c42-e72f-4414-89be-1e5b677be020)
 
-
 ## Installation
 
 1. Open your terminal and go to your Craft project:
+
    ```bash
    cd /path/to/project
    ```
 
 2. Install via Composer:
+
    ```bash
    composer require statikbe/craft-config-values
    ```
 
 3. Install the plugin via Craft CLI:
+
    ```bash
    ./craft plugin/install config-values-field
    ```
@@ -43,7 +46,24 @@ return [
             'outline' => 'Outline Button',
             'link' => 'Text Link',
         ],
-        
+
+        // Basic dropdown but with values differing per site
+	// Important: If you want to configure datasets per site you should always make at minimum a dataset for the primary site as fallback
+        'ctaStylesSiteDependent' => [
+            'primarySiteHandle' => [
+                'primary' => 'Primary Button',
+                'secondary' => 'Secondary Button',
+                'outline' => 'Outline Button',
+                'link' => 'Text Link',
+            ],
+            'secondarySiteHandle' => [
+                'alternative' => 'Primary Button',
+                'secondary alternative' => 'Secondary Button',
+                'outline' => 'Outline Button',
+                'link' => 'Text Link',
+            ],
+        ],
+
         // Color options (supports hex values)
         'brandColors' => [
             '' => 'none',      // Special: shows striped pattern
@@ -53,7 +73,7 @@ return [
             'accent' => '#F59E0B',
             'danger' => '#EF4444',
         ],
-        
+
         // Gradient colors (2-3 colors)
         'headerColors' => [
             '' => 'none',      // Special: shows striped pattern
@@ -62,7 +82,7 @@ return [
             'ocean' => ['#667eea', '#764ba2', '#f093fb'],
             'forest' => ['#134e5e', '#71b280'],
         ],
-        
+
         // Shape options (requires SVG files)
         'icons' => [
             'path' => '@webroot/assets/icons/',
@@ -84,16 +104,21 @@ return [
 The plugin supports 5 different field display types:
 
 ### 1. Dropdown
+
 Standard select dropdown for single selection.
 
 ### 2. Radio Buttons
+
 Radio button group for single selection with visual options.
 
 ### 3. Checkboxes
+
 Multiple selection checkboxes for choosing multiple values.
 
 ### 4. Color
+
 Visual color picker with special features:
+
 - Hex colors: Display as color swatches
 - Gradients: Support 2-3 color arrays for gradient backgrounds
 - Special values:
@@ -101,7 +126,9 @@ Visual color picker with special features:
   - `'none'`: Shows striped "no color" pattern
 
 ### 5. Shape
+
 SVG shape selector for icon/graphic selection:
+
 - Requires `path` configuration pointing to SVG directory
 - Uses `shapes` array to map filenames to labels
 - Validates file existence
@@ -109,9 +136,6 @@ SVG shape selector for icon/graphic selection:
   - `'random'`
   - `'none'`
 
-
-
-
----
+______________________________________________________________________
 
 Brought to you by [Statik.be](https://www.statik.be)

--- a/src/ConfigValuesField.php
+++ b/src/ConfigValuesField.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Config Values Field plugin for Craft CMS 3.x
  *
@@ -10,13 +11,14 @@
 
 namespace statikbe\configvaluesfield;
 
+use Craft;
 use craft\base\Model;
 use craft\base\Plugin;
-
 use craft\events\RegisterComponentTypesEvent;
 use craft\services\Fields;
+use craft\services\Sites;
+use craft\web\Request;
 use statikbe\configvaluesfield\fields\ConfigValuesFieldField as ConfigValuesFieldFieldField;
-
 use statikbe\configvaluesfield\models\Settings;
 use yii\base\Event;
 
@@ -57,13 +59,15 @@ class ConfigValuesField extends Plugin
         parent::init();
         self::$plugin = $this;
 
-        Event::on(
-            Fields::class,
-            Fields::EVENT_REGISTER_FIELD_TYPES,
-            function(RegisterComponentTypesEvent $event) {
-                $event->types[] = ConfigValuesFieldFieldField::class;
-            }
-        );
+        Craft::$app->onInit(function () {
+            Event::on(
+                Fields::class,
+                Fields::EVENT_REGISTER_FIELD_TYPES,
+                function (RegisterComponentTypesEvent $event) {
+                    $event->types[] = ConfigValuesFieldFieldField::class;
+                }
+            );
+        });
     }
 
     // Protected Methods
@@ -74,5 +78,39 @@ class ConfigValuesField extends Plugin
     protected function createSettingsModel(): Model
     {
         return new Settings();
+    }
+
+    public function getSiteSpecificOptions(string $dataSetKey): array
+    {
+        /** @var Sites $sites */
+        $sites = Craft::$app->sites;
+        /** @var Request $request */
+        $request = Craft::$app->getRequest();
+
+        $requestedSiteHandle = $request->getQueryParam('site');
+
+        $primarySiteHandle = $sites->primarySite->handle;
+        if ($requestedSiteHandle) {
+            $site = $sites->getSiteByHandle($requestedSiteHandle);
+        } else {
+            $site = $sites->currentSite;
+        }
+        $siteHandle = $site ? $site->handle : $primarySiteHandle;
+
+        $settings = $this->getSettings()->data;
+        $settings = $settings[$dataSetKey] ?? [];
+
+        // INFO: if no primary site or current site handle is present in the config we assume no site specific settings
+        if (!isset($settings[$primarySiteHandle]) && !isset($settings[$siteHandle])) {
+            return $settings;
+        }
+
+        // INFO: IF we have a site specific config we return it
+        if (isset($settings[$siteHandle])) {
+            return $settings[$siteHandle];
+        }
+
+        // INFO: In this case we have site specific settings but not for the current site
+        return $settings[$primarySiteHandle];
     }
 }

--- a/src/config.php
+++ b/src/config.php
@@ -1,5 +1,33 @@
 <?php
 
 return [
-    'data' => [],
+    '*' => [
+        'data' => [
+            // EXAMPLE: having different data for different sites
+            'Background colors' => [
+                'primarySiteHandle' => [
+                    'section--default' => 'Default',
+                    'section--light' => 'Light',
+                    'section--primary' => 'Primary',
+                ],
+                'secondarySiteHandle' => [
+                    'section--default' => 'Default',
+                    'section--light' => 'Light',
+                    'section--primary' => 'Primary',
+                ],
+            ],
+            // EXAMPLE: Or just one data set for all sites
+            'CTA styles' => [
+                'btn btn--primary btn--ext' => 'Primary >',
+                'btn btn--secondary btn--ext' => 'Secondary >',
+                'link link--ext' => 'Link >',
+            ],
+        ],
+    ],
+    'production' => [
+        // Production config
+    ],
+    'dev' => [
+        // Development config
+    ]
 ];

--- a/src/fields/ConfigValuesFieldField.php
+++ b/src/fields/ConfigValuesFieldField.php
@@ -18,8 +18,8 @@ use craft\base\InlineEditableFieldInterface;
 use craft\base\SortableFieldInterface;
 use craft\helpers\App;
 use statikbe\configvaluesfield\assetbundles\configvalues\ConfigValuesAsset;
-use statikbe\configvaluesfield\ConfigValuesField;
 use statikbe\configvaluesfield\fields\conditions\ConfigValuesFieldConditionRule;
+use statikbe\configvaluesfield\ConfigValuesField;
 
 /**
  * @author    Statik.be
@@ -183,7 +183,8 @@ class ConfigValuesFieldField extends Field implements InlineEditableFieldInterfa
 
         // Get our id and namespace
         $id = Craft::$app->getView()->formatInputId($this->handle);
-        $options = ConfigValuesField::getInstance()->getSettings()->data[$this->dataSet];
+
+        $options = ConfigValuesField::getInstance()->getSiteSpecificOptions($this->dataSet);
 
         // Render the input template
         Craft::$app->getView()->registerAssetBundle(ConfigValuesAsset::class);


### PR DESCRIPTION
### Description

Allows developers to specify differing values for each subsite per dataset. 

### Reason for this change

With craft 5 it is very common to reuse the same fields many times across entrytypes and subsites. However you might want to give the user different options to choose from within the same dataset. For example background colors blue red and white for primary site and yellow, green, purple for secondary site.  Having to split up all entrytypes that would require this field to accomodate this in craft 5 would become very messy. therefor this feature.